### PR TITLE
fix: parse error

### DIFF
--- a/layouts/Linux/xkb/symbols/universal
+++ b/layouts/Linux/xkb/symbols/universal
@@ -139,7 +139,7 @@ xkb_symbols "universal" {
     };
     key <AD09> {
         type = "FOUR_LEVEL_ALPHABETIC",
-        symbols[Group1] = [ o,     O,    ],
+        symbols[Group1] = [ o,     O     ],
         symbols[Group2] = [ U0449, U0429 ]
     };
     key <AD10> {


### PR DESCRIPTION
Запятая вызывает ошибку
```
syntax error: line 142 of /home/vmerk/g/universal-layout/layouts/Linux/xkb/symbols/universal
last scanned symbol is: O
Errors encountered in /home/vmerk/g/universal-layout/layouts/Linux/xkb/symbols/universal; not compiled.
```